### PR TITLE
Set and clear cleaners door code based on calendar

### DIFF
--- a/.github/workflows/check_config.yml
+++ b/.github/workflows/check_config.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: [ opened ]
   schedule:
     # Run on the 15th of the month at 9am
     - cron: '0 9 15 * *'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ secrets.yaml
 .storage/
 .vscode/
 *.xml
+google_calendars.yaml
+.google.token

--- a/automation/lock.yaml
+++ b/automation/lock.yaml
@@ -42,3 +42,33 @@
       entity_id: cover.garage
     - service: lock.lock
       entity_id: lock.front_door
+
+- alias: Enable Cleaners Lock Code
+  trigger:
+    - platform: state
+      entity_id: calendar.house_planning
+      to: 'on'
+    - platform: template
+      value_template: "{{ state_attr('calendar.house_planning', 'offset_reached') }}"
+  action:
+    - service: mqtt.publish
+      data:
+        topic: zwave2mqtt/4/99/1/16/set
+        payload: !secret cleaners_door_code_json
+    - service: notify.mobile_app_michaels_iphone
+      data:
+        message: "Setting cleaners lock code"
+
+- alias: Cleaners Clear Code
+  trigger:
+    - platform: state
+      entity_id: calendar.house_planning
+      to: 'off'
+  action:
+    - service: mqtt.publish
+      data:
+        topic: zwave2mqtt/4/99/1/256/set
+        payload: "{\"value\": 16}"
+    - service: notify.mobile_app_michaels_iphone
+      data:
+        message: "Clearing cleaners lock code"

--- a/config/google.yaml
+++ b/config/google.yaml
@@ -1,0 +1,2 @@
+client_id: !secret gcal_client_id
+client_secret: !secret gcal_client_secret

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -23,6 +23,7 @@ binary_sensor: !include_dir_merge_list binary_sensor
 camera: !include config/camera.yaml
 cover: !include config/covers.yaml
 group: !include config/groups.yaml
+google: !include config/google.yaml
 homekit: !include config/homekit.yaml
 input_boolean: !include config/input_boolean.yaml
 ios: !include config/ios.yaml

--- a/test_secrets.yaml
+++ b/test_secrets.yaml
@@ -7,3 +7,6 @@ myq_username: email
 myq_password: foo
 baby_cam_snap: foo
 baby_cam_stream: foo
+cleaners_door_code_json: foo
+gcal_client_id: foo
+gcal_client_secret: foo


### PR DESCRIPTION
Use gcal with offet tracking to add door code before appointment is scheduled to happen. 

Clear it when calendar ends.